### PR TITLE
chore: sync project.version to upstream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ context = { version = '0.55.2' }
 [tool.pack-binary.project]
 name = "dprint-py"
 requires-python = ">=3.0"
-version = '0.55.1.4'
+version = '0.55.2.0'
 description = "a pluggable and configurable code formatting platform."
 readme = "readme.md"
 license = "MIT"


### PR DESCRIPTION
Automatically synced `project.version` to match upstream `context.version`.